### PR TITLE
[chrome.v8] fixed the error libs not defined

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -5483,6 +5483,8 @@ v8_component("v8_libbase") {
 
   defines = []
 
+  libs = []
+
   if (is_component_build) {
     defines = [ "BUILDING_V8_BASE_SHARED" ]
   }


### PR DESCRIPTION
when gn with target_os = "android" and target_cpu = "riscv64"

libs may be not defined when goto

```
  if (v8_current_cpu == "riscv64" || v8_current_cpu == "riscv32") {
    libs += [ "atomic" ]
  }
```