### PR TITLE
[chrome.v8] catch up with upstream

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -252,6 +252,7 @@ Sylvestre Ledru <sledru@mozilla.com>
 Takeshi Yoneda <takeshi@tetrate.io>
 Taketoshi Aono <brn@b6n.ch>
 Tao Liqiang <taolq@outlook.com>
+Tao Wang <tao.wang.2261@gmail.com>
 Teddy Katz <teddy.katz@gmail.com>
 Thomas Young <wenzhang5800@gmail.com>
 Tiancheng "Timothy" Gu <timothygu99@gmail.com>
@@ -268,6 +269,7 @@ Vlad Burlik <vladbph@gmail.com>
 Vladimir Krivosheev <develar@gmail.com>
 Vladimir Shutoff <vovan@shutoff.ru>
 Wael Almattar <waelsy123@gmail.com>
+Wang Chen <wangchen20@iscas.ac.cn>
 WANG Xuerui <git@xen0n.name>
 Wei Wu <lazyparser@gmail.com>
 Wenlu Wang <kingwenlu@gmail.com>

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -720,7 +720,9 @@ config("internal_config") {
   }
 
   if (v8_current_cpu == "riscv64" || v8_current_cpu == "riscv32") {
-    libs = [ "atomic" ]
+    if (!is_clang) {
+      libs = [ "atomic" ]
+    }
   }
 }
 
@@ -792,7 +794,9 @@ config("external_config") {
   }
 
   if (current_cpu == "riscv64" || current_cpu == "riscv32") {
-    libs = [ "atomic" ]
+    if (!is_clang) {
+      libs = [ "atomic" ]
+    }
   }
 }
 
@@ -5548,7 +5552,9 @@ v8_source_set("v8_base_without_compiler") {
       v8_current_cpu == "ppc" || v8_current_cpu == "ppc64" ||
       v8_current_cpu == "s390" || v8_current_cpu == "s390x" ||
       v8_current_cpu == "riscv64" || v8_current_cpu == "riscv32") {
-    libs += [ "atomic" ]
+    if (!is_clang) {
+      libs += [ "atomic" ]
+    }
   }
 
   if (v8_enable_vtunetracemark && (is_linux || is_chromeos || is_win)) {
@@ -5946,7 +5952,9 @@ v8_component("v8_libbase") {
   }
 
   if (v8_current_cpu == "riscv64" || v8_current_cpu == "riscv32") {
-    libs += [ "atomic" ]
+    if (!is_clang) {
+      libs += [ "atomic" ]
+    }
   }
 
   if (is_tsan && !build_with_chromium) {
@@ -6054,7 +6062,9 @@ v8_component("v8_libplatform") {
   }
 
   if (v8_current_cpu == "riscv64" || v8_current_cpu == "riscv32") {
-    libs = [ "atomic" ]
+    if (!is_clang) {
+      libs = [ "atomic" ]
+    }
   }
 }
 
@@ -6993,7 +7003,9 @@ v8_executable("cppgc_hello_world") {
   sources = [ "samples/cppgc/hello-world.cc" ]
 
   if (v8_current_cpu == "riscv64" || v8_current_cpu == "riscv32") {
-    libs = [ "atomic" ]
+    if (!is_clang) {
+      libs = [ "atomic" ]
+    }
   }
 
   configs = [

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -5829,6 +5829,8 @@ v8_component("v8_libbase") {
 
   deps = [ ":v8_config_headers" ]
 
+  libs = []
+
   data = []
 
   data_deps = []

--- a/src/codegen/riscv/cpu-riscv.cc
+++ b/src/codegen/riscv/cpu-riscv.cc
@@ -15,12 +15,16 @@ namespace internal {
 void CpuFeatures::FlushICache(void* start, size_t size) {
 #if !defined(USE_SIMULATOR)
   char* end = reinterpret_cast<char*>(start) + size;
-  // The definition of this syscall is
+  // The definition of this syscall is equal to
   // SYSCALL_DEFINE3(riscv_flush_icache, uintptr_t, start,
   //                 uintptr_t, end, uintptr_t, flags)
   // The flag here is set to be SYS_RISCV_FLUSH_ICACHE_LOCAL, which is
   // defined as 1 in the Linux kernel.
-  syscall(SYS_riscv_flush_icache, start, end, 1);
+  // SYS_riscv_flush_icache is a symbolic constant used in user-space code to
+  // identify the flush_icache system call, while __NR_riscv_flush_icache is the
+  // corresponding system call number used in the kernel to dispatch the system
+  // call.
+  syscall(__NR_riscv_flush_icache, start, end, 1);
 #endif  // !USE_SIMULATOR.
 }
 

--- a/test/unittests/BUILD.gn
+++ b/test/unittests/BUILD.gn
@@ -94,7 +94,9 @@ if (cppgc_is_standalone) {
   v8_executable("cppgc_unittests") {
     testonly = true
     if (v8_current_cpu == "riscv64" || v8_current_cpu == "riscv32") {
-      libs = [ "atomic" ]
+      if (!is_clang) {
+        libs = [ "atomic" ]
+      }
     }
 
     configs = [


### PR DESCRIPTION
v8 仓库的 diff 改动比较简单，和 upstream 的比对已完成，详细分析请看附件：
[diff.v8.txt](https://github.com/aosp-riscv/v8/files/11621463/diff.v8.txt)
